### PR TITLE
Fix typo in script and clarify README title

### DIFF
--- a/.devcontainer/set_git_conig_from_gh.sh
+++ b/.devcontainer/set_git_conig_from_gh.sh
@@ -3,4 +3,4 @@ user=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version:
 email=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /user/emails | jq -r ".[0].email")
 echo "Setting $user <$email> as the default Git user..."
 git config --global user.name "$user"
-git config --global user.email "$email" ch
+git config --global user.email "$email"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CursorMinimalDevEnv
+# Cursor Minimal Development Environment Repository
 
 A minimal development environment setup for Cursor editor using Dev Containers.
 


### PR DESCRIPTION
Corrected a typo in the shell script to ensure proper setting of the Git user email without extra characters. Updated the README to improve clarity of the repository name, enhancing understanding for users regarding its purpose.